### PR TITLE
Support PHP 7.1 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.1
   - 7.2
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "name": "tobscure/json-api-server",
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "doctrine/inflector": "^1.3",
-        "json-api-php/json-api": "^2.0",
+        "json-api-php/json-api": "^2.0.1",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "spatie/macroable": "^1.0",


### PR DESCRIPTION
Because of https://github.com/json-api-php/json-api/issues/89, this is now easily possible again, making the lib compatible with Flarum's minimum requirements. :)