### PR TITLE
Implement content negotiation

### DIFF
--- a/src/Exception/NotAcceptableException.php
+++ b/src/Exception/NotAcceptableException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tobscure\JsonApiServer\Exception;
+
+use RuntimeException;
+
+class NotAcceptableException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('None of the accepted media types can be provided');
+    }
+
+    public function getStatusCode()
+    {
+        return 406;
+    }
+}

--- a/src/Exception/UnsupportedMediaTypeException.php
+++ b/src/Exception/UnsupportedMediaTypeException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tobscure\JsonApiServer\Exception;
+
+use RuntimeException;
+
+class UnsupportedMediaTypeException extends RuntimeException
+{
+    public function __construct(string $type)
+    {
+        parent::__construct("Can not parse the [$type] media type.");
+    }
+
+    public function getStatusCode()
+    {
+        return 415;
+    }
+}

--- a/src/Http/MediaTypes.php
+++ b/src/Http/MediaTypes.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tobscure\JsonApiServer\Http;
+
+class MediaTypes
+{
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Determine whether the list contains the given type without modifications
+     *
+     * This is meant to ease implementation of JSON:API rules for content
+     * negotiation, which demand HTTP error responses e.g. when all of the
+     * JSON:API media types in the "Accept" header are modified with "media type
+     * parameters". Therefore, this method only returns true when the requested
+     * media type is contained without additional parameters (except for the
+     * weight parameter "q" and "Accept extension parameters").
+     *
+     * @param string $mediaType
+     * @return bool
+     */
+    public function containsExactly(string $mediaType): bool
+    {
+        $types = array_map('trim', explode(',', $this->value));
+
+        // Accept headers can contain multiple media types, so we need to check
+        // whether any of them matches.
+        foreach ($types as $type) {
+            $parts = array_map('trim', explode(';', $type));
+
+            // The actual media type needs to be an exact match
+            if (array_shift($parts) !== $mediaType) {
+                continue;
+            }
+
+            // The media type can optionally be followed by "media type
+            // parameters". Parameters after the "q" parameter are considered
+            // "Accept extension parameters", which we don't care about. Thus,
+            // we have an exact match if there are no parameters at all or if
+            // the first one is named "q".
+            // See https://tools.ietf.org/html/rfc7231#section-5.3.2.
+            if (empty($parts) || substr($parts[0], 0, 2) === 'q=') {
+                return true;
+            }
+
+            continue;
+        }
+
+        return false;
+    }
+}

--- a/src/JsonApiResponse.php
+++ b/src/JsonApiResponse.php
@@ -12,7 +12,7 @@ class JsonApiResponse extends JsonResponse
         array $headers = [],
         $encodingOptions = self::DEFAULT_JSON_FLAGS
     ) {
-        $headers['content-type'] = 'application/vnd.api+json';
+        $headers['content-type'] = Api::CONTENT_TYPE;
 
         parent::__construct($data, $status, $headers, $encodingOptions);
     }

--- a/tests/specification/ContentNegotiationTest.php
+++ b/tests/specification/ContentNegotiationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of JSON-API.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tobscure\Tests\JsonApiServer\specification;
+
+use Tobscure\JsonApiServer\Api;
+use Tobscure\JsonApiServer\Exception\NotAcceptableException;
+use Tobscure\JsonApiServer\Exception\UnsupportedMediaTypeException;
+use Tobscure\JsonApiServer\Schema\Builder;
+use Tobscure\Tests\JsonApiServer\AbstractTestCase;
+use Tobscure\Tests\JsonApiServer\MockAdapter;
+
+class ContentNegotiationTest extends AbstractTestCase
+{
+    /**
+     * @var Api
+     */
+    private $api;
+
+    public function setUp()
+    {
+        $this->api = new Api('http://example.com');
+        $this->api->resource('users', new MockAdapter(), function (Builder $schema) {
+            // no fields
+        });
+    }
+
+    public function testJsonApiContentTypeIsReturned()
+    {
+        $response = $this->api->handle(
+            $this->buildRequest('GET', '/users/1')
+        );
+
+        $this->assertEquals(
+            'application/vnd.api+json',
+            $response->getHeaderLine('Content-Type')
+        );
+    }
+
+    public function testErrorWhenValidRequestContentTypeHasParameters()
+    {
+        $request = $this->buildRequest('PATCH', '/users/1')
+            ->withHeader('Content-Type', 'application/vnd.api+json;profile="http://example.com/last-modified"');
+
+        $this->expectException(UnsupportedMediaTypeException::class);
+
+        $this->api->handle($request);
+    }
+
+    public function testErrorWhenAllValidAcceptsHaveParameters()
+    {
+        $request = $this->buildRequest('GET', '/users/1')
+            ->withHeader('Accept', 'application/vnd.api+json;profile="http://example.com/last-modified", application/vnd.api+json;profile="http://example.com/versioning"');
+
+        $this->expectException(NotAcceptableException::class);
+
+        $this->api->handle($request);
+    }
+
+    public function testSuccessWhenOnlySomeAcceptsHaveParameters()
+    {
+        $response = $this->api->handle(
+            $this->buildRequest('GET', '/users/1')
+                ->withHeader('Accept', 'application/vnd.api+json;profile="http://example.com/last-modified", application/vnd.api+json')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Http/MediaTypesTest.php
+++ b/tests/unit/Http/MediaTypesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of JSON-API.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tobscure\Tests\JsonApiServer\unit\Http;
+
+use PHPUnit\Framework\TestCase;
+use Tobscure\JsonApiServer\Http\MediaTypes;
+
+class MediaTypesTest extends TestCase
+{
+    public function testContainsOnExactMatch()
+    {
+        $header = new MediaTypes('application/json');
+
+        $this->assertTrue(
+            $header->containsExactly('application/json')
+        );
+    }
+
+    public function testContainsDoesNotMatchWithExtraParameters()
+    {
+        $header = new MediaTypes('application/json; profile=foo');
+
+        $this->assertFalse(
+            $header->containsExactly('application/json')
+        );
+    }
+
+    public function testContainsMatchesWhenOnlyWeightIsProvided()
+    {
+        $header = new MediaTypes('application/json; q=0.8');
+
+        $this->assertTrue(
+            $header->containsExactly('application/json')
+        );
+    }
+
+    public function testContainsDoesNotMatchWithExtraParametersBeforeWeight()
+    {
+        $header = new MediaTypes('application/json; profile=foo; q=0.8');
+
+        $this->assertFalse(
+            $header->containsExactly('application/json')
+        );
+    }
+
+    public function testContainsMatchesWithExtraParametersAfterWeight()
+    {
+        $header = new MediaTypes('application/json; q=0.8; profile=foo');
+
+        $this->assertTrue(
+            $header->containsExactly('application/json')
+        );
+    }
+
+    public function testContainsMatchesWhenOneOfMultipleMediaTypesIsValid()
+    {
+        $header = new MediaTypes('application/json; profile=foo, application/json; q=0.6');
+
+        $this->assertTrue(
+            $header->containsExactly('application/json')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #10.

This consists of the following:
- Feature tests for content negotiation, according to JSON:API spec version 1.0
- A helper class for evaluating media types (either from the `Content-Type` or the `Accept` header). The latter one is a bit tricky, because it has multiple types of parameters, if I understand [the HTTP specification](https://tools.ietf.org/html/rfc7231#section-5.3.2) correctly. The JSON:API spec doesn't mention these explicitly, but if the wording is intentional, they are only talking about the first type of parameters, so that is what I implemented.
- Unit tests for this helper class (taking care of the real edge cases, which didn't matter much for the feature tests)
- A small refactoring in the `Api` class, to make the `handle()` method easier to understand

I started grouping the new test cases in a way that makes sense to me, keeping in mind the discussion in #1.

Please take an extra look at the test cases (they should explain the behavior pretty well), whether they seem to be in accordance with the spec(s) in your eyes.